### PR TITLE
Update to use PayPalIDToken instead of PayPalUAT

### DIFF
--- a/Demo/DemoMerchantAPI.swift
+++ b/Demo/DemoMerchantAPI.swift
@@ -28,8 +28,8 @@ typealias PurchaseUnit = CreateOrderParams.PurchaseUnit
 typealias Amount = CreateOrderParams.PurchaseUnit.Amount
 typealias Payee = CreateOrderParams.PurchaseUnit.Payee
 
-// TODO: rename all instances of UAT to either ClientToken or IDToken in the PPCP and BT SDKs
-struct UAT: Codable {
+// TODO: rename all instances of ID Token to either ClientToken or IDToken in the PPCP and BT SDKs
+struct IDToken: Codable {
     let idToken: String
 }
 
@@ -73,7 +73,7 @@ class DemoMerchantAPI {
         }.resume()
     }
 
-    func generateUAT(countryCode: String, completion: @escaping ((String?, Error?) -> Void)) {
+    func generateIDToken(countryCode: String, completion: @escaping ((String?, Error?) -> Void)) {
         var components = URLComponents(url: DemoSettings.sampleMerchantServerURL, resolvingAgainstBaseURL: false)!
         components.path = "/id-token"
         components.queryItems = [URLQueryItem(name: "countryCode", value: countryCode)]
@@ -90,8 +90,8 @@ class DemoMerchantAPI {
             do {
                 let decoder = JSONDecoder()
                 decoder.keyDecodingStrategy = .convertFromSnakeCase
-                let uat = try decoder.decode(UAT.self, from: data)
-                completion(uat.idToken, nil)
+                let idToken = try decoder.decode(IDToken.self, from: data)
+                completion(idToken.idToken, nil)
             } catch (let parseError) {
                 completion(nil, parseError)
             }

--- a/Demo/DemoMerchantAPI.swift
+++ b/Demo/DemoMerchantAPI.swift
@@ -28,7 +28,6 @@ typealias PurchaseUnit = CreateOrderParams.PurchaseUnit
 typealias Amount = CreateOrderParams.PurchaseUnit.Amount
 typealias Payee = CreateOrderParams.PurchaseUnit.Payee
 
-// TODO: rename all instances of ID Token to either ClientToken or IDToken in the PPCP and BT SDKs
 struct IDToken: Codable {
     let idToken: String
 }

--- a/Demo/DemoViewController.swift
+++ b/Demo/DemoViewController.swift
@@ -10,7 +10,7 @@ class DemoViewController: UIViewController, BTViewControllerPresentingDelegate {
     @IBOutlet weak var orderResultLabel: UILabel!
     @IBOutlet weak var processOrderButton: UIButton!
     @IBOutlet weak var checkoutResultLabel: UILabel!
-    @IBOutlet weak var uatLabel: UILabel!
+    @IBOutlet weak var idTokenLabel: UILabel!
     @IBOutlet weak var otherCheckoutStackView: UIStackView!
     
     private var orderID: String?
@@ -25,14 +25,14 @@ class DemoViewController: UIViewController, BTViewControllerPresentingDelegate {
         applePayButton.addTarget(self, action: #selector(applePayCheckoutTapped(_:)), for: .touchUpInside)
         otherCheckoutStackView.addArrangedSubview(applePayButton)
         
-        generateUAT()
+        generateIDToken()
     }
 
     override func viewWillAppear(_ animated: Bool) {
         amountTextField.text = "10.00"
         payeeEmailTextField.text = DemoSettings.payeeEmailAddress
 
-        generateUAT()
+        generateIDToken()
         processOrderButton.setTitle("\(DemoSettings.intent.capitalized) Order", for: .normal)
     }
 
@@ -150,7 +150,7 @@ class DemoViewController: UIViewController, BTViewControllerPresentingDelegate {
     }
     
     @IBAction func refreshTapped(_ sender: Any) {
-        generateUAT()
+        generateIDToken()
     }
 
     // MARK: - Construct order/request helpers
@@ -184,16 +184,16 @@ class DemoViewController: UIViewController, BTViewControllerPresentingDelegate {
         return card
     }
 
-    func generateUAT() {
-        updateUATLabel(withText: "Fetching UAT...")
-        DemoMerchantAPI.sharedService.generateUAT(countryCode: DemoSettings.countryCode) { (uat, error) in
-            guard let uat = uat, error == nil else {
-                self.updateUATLabel(withText: "Failed to fetch UAT: \(error!.localizedDescription). Tap refresh to try again.")
+    func generateIDToken() {
+        updateIDTokenLabel(withText: "Fetching ID Token...")
+        DemoMerchantAPI.sharedService.generateIDToken(countryCode: DemoSettings.countryCode) { (idToken, error) in
+            guard let idToken = idToken, error == nil else {
+                self.updateIDTokenLabel(withText: "Failed to fetch ID Token: \(error!.localizedDescription). Tap refresh to try again.")
                 return
             }
 
-            self.updateUATLabel(withText: "Fetched UAT: \(uat)")
-            self.payPalClient = PYPLClient(accessToken: uat)
+            self.updateIDTokenLabel(withText: "Fetched ID Token: \(idToken)")
+            self.payPalClient = PYPLClient(idToken: idToken)
             self.payPalClient?.presentingDelegate = self
         }
     }
@@ -219,9 +219,9 @@ class DemoViewController: UIViewController, BTViewControllerPresentingDelegate {
         }
     }
 
-    private func updateUATLabel(withText text: String) {
+    private func updateIDTokenLabel(withText text: String) {
         DispatchQueue.main.async {
-            self.uatLabel.text = text
+            self.idTokenLabel.text = text
         }
     }
 

--- a/Demo/Main.storyboard
+++ b/Demo/Main.storyboard
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15702" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="ll6-sJ-eTR">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
+        <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15704"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -29,20 +31,20 @@
             <objects>
                 <viewController id="iJp-4K-KX8" customClass="DemoViewController" customModule="Demo" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="6Yq-k6-mKL">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="KZS-EK-rRA">
-                                <rect key="frame" x="20" y="20" width="560" height="452"/>
+                                <rect key="frame" x="20" y="108" width="374" height="450"/>
                                 <subviews>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="UAT: None" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Rp4-E7-fI3">
-                                        <rect key="frame" x="0.0" y="0.0" width="77" height="20"/>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="ID Token: None" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Rp4-E7-fI3">
+                                        <rect key="frame" x="0.0" y="0.0" width="110" height="19.5"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                         <color key="textColor" systemColor="systemPinkColor" red="1" green="0.1764705882" blue="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="seller123@paypal.com" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="QBp-YO-Sus">
-                                        <rect key="frame" x="0.0" y="30" width="560" height="34"/>
+                                        <rect key="frame" x="0.0" y="29.5" width="374" height="34"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="34" id="8jU-iZ-gfX"/>
                                         </constraints>
@@ -50,12 +52,12 @@
                                         <textInputTraits key="textInputTraits"/>
                                     </textField>
                                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="10.00" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="zOy-Wa-yG6">
-                                        <rect key="frame" x="0.0" y="74" width="560" height="34"/>
+                                        <rect key="frame" x="0.0" y="73.5" width="374" height="34"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <textInputTraits key="textInputTraits"/>
                                     </textField>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="GNA-Ua-Fnl">
-                                        <rect key="frame" x="0.0" y="118" width="95" height="32"/>
+                                        <rect key="frame" x="0.0" y="117.5" width="95" height="32"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                         <state key="normal" title="Create Order"/>
                                         <connections>
@@ -63,33 +65,33 @@
                                         </connections>
                                     </button>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Order ID: None " textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dEW-VJ-XL1">
-                                        <rect key="frame" x="0.0" y="160" width="113" height="20"/>
+                                        <rect key="frame" x="0.0" y="159.5" width="113" height="19.5"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="KXp-aq-MK9">
-                                        <rect key="frame" x="0.0" y="190" width="560" height="2"/>
+                                        <rect key="frame" x="0.0" y="189" width="374" height="2"/>
                                         <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="2" id="900-Fn-6Q7"/>
                                         </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Xzh-9M-JWr">
-                                        <rect key="frame" x="0.0" y="202" width="560" height="10"/>
+                                        <rect key="frame" x="0.0" y="201" width="374" height="10"/>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="10" id="kJh-9e-QZk"/>
                                         </constraints>
                                     </view>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Card Checkout" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gVC-X1-JTF">
-                                        <rect key="frame" x="0.0" y="222" width="109" height="20"/>
+                                        <rect key="frame" x="0.0" y="221" width="108.5" height="19.5"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                         <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Card Number" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="fod-bU-K5o">
-                                        <rect key="frame" x="0.0" y="252" width="560" height="34"/>
+                                        <rect key="frame" x="0.0" y="250.5" width="374" height="34"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="34" id="jvq-ze-d5q"/>
                                         </constraints>
@@ -97,10 +99,10 @@
                                         <textInputTraits key="textInputTraits"/>
                                     </textField>
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" alignment="top" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="hLr-aI-LM9">
-                                        <rect key="frame" x="0.0" y="296" width="560" height="34"/>
+                                        <rect key="frame" x="0.0" y="294.5" width="374" height="34"/>
                                         <subviews>
                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="MM/YY" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="LDI-1m-9Dh">
-                                                <rect key="frame" x="0.0" y="0.0" width="216" height="34"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="145" height="34"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="34" id="43D-62-dNW"/>
                                                 </constraints>
@@ -108,7 +110,7 @@
                                                 <textInputTraits key="textInputTraits"/>
                                             </textField>
                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="CVV" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="fRx-AA-fHQ">
-                                                <rect key="frame" x="221" y="0.0" width="282" height="34"/>
+                                                <rect key="frame" x="150" y="0.0" width="167" height="34"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="34" id="RyJ-aX-rNp"/>
                                                 </constraints>
@@ -116,7 +118,7 @@
                                                 <textInputTraits key="textInputTraits"/>
                                             </textField>
                                             <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Zv2-MC-74k">
-                                                <rect key="frame" x="508" y="0.0" width="52" height="32"/>
+                                                <rect key="frame" x="322" y="0.0" width="52" height="32"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                                 <state key="normal" title="Submit"/>
                                                 <connections>
@@ -126,16 +128,16 @@
                                         </subviews>
                                     </stackView>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Other Checkout" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9yL-iz-1fk">
-                                        <rect key="frame" x="0.0" y="340" width="115" height="20"/>
+                                        <rect key="frame" x="0.0" y="338.5" width="115" height="19.5"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                         <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="30" translatesAutoresizingMaskIntoConstraints="NO" id="8gi-nF-pug">
-                                        <rect key="frame" x="0.0" y="370" width="560" height="30"/>
+                                        <rect key="frame" x="0.0" y="368" width="374" height="30"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="BH0-bf-ERQ">
-                                                <rect key="frame" x="0.0" y="0.0" width="560" height="30"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="374" height="30"/>
                                                 <color key="backgroundColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <state key="normal" title="PayPal">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -148,7 +150,7 @@
                                         <color key="backgroundColor" systemColor="linkColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     </stackView>
                                     <button opaque="NO" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="yQl-Nj-vT3">
-                                        <rect key="frame" x="0.0" y="410" width="104" height="32"/>
+                                        <rect key="frame" x="0.0" y="408" width="104" height="32"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                         <state key="normal" title="Process Order"/>
                                         <connections>
@@ -156,7 +158,7 @@
                                         </connections>
                                     </button>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jwJ-J1-9do">
-                                        <rect key="frame" x="0.0" y="452" width="0.0" height="0.0"/>
+                                        <rect key="frame" x="0.0" y="450" width="0.0" height="0.0"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
@@ -192,7 +194,7 @@
                         <barButtonItem key="leftBarButtonItem" systemItem="refresh" id="VGw-oV-txt">
                             <color key="tintColor" systemColor="systemPinkColor" red="1" green="0.1764705882" blue="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             <connections>
-                                <action selector="refreshTapped:" destination="iJp-4K-KX8" id="DA4-Fe-CoH"/>
+                                <action selector="refreshTapped:" destination="iJp-4K-KX8" id="jQg-c6-55Y"/>
                             </connections>
                         </barButtonItem>
                         <barButtonItem key="rightBarButtonItem" id="Sle-XL-5uC">
@@ -212,11 +214,11 @@
                         <outlet property="checkoutResultLabel" destination="jwJ-J1-9do" id="gmC-Sj-lyE"/>
                         <outlet property="cvvTextField" destination="fRx-AA-fHQ" id="92z-tI-LFS"/>
                         <outlet property="expirationDateTextField" destination="LDI-1m-9Dh" id="Csi-FA-MzF"/>
+                        <outlet property="idTokenLabel" destination="Rp4-E7-fI3" id="obg-4I-n1E"/>
                         <outlet property="orderResultLabel" destination="dEW-VJ-XL1" id="mqy-fC-rJH"/>
                         <outlet property="otherCheckoutStackView" destination="8gi-nF-pug" id="bda-2e-Q1w"/>
                         <outlet property="payeeEmailTextField" destination="QBp-YO-Sus" id="cUu-IE-ulE"/>
                         <outlet property="processOrderButton" destination="yQl-Nj-vT3" id="m39-De-3MM"/>
-                        <outlet property="uatLabel" destination="Rp4-E7-fI3" id="Jn1-Yj-qQt"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="QAo-7c-wLj" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>

--- a/IntegrationTests/Helpers/IntegrationTests_MerchantAPI.swift
+++ b/IntegrationTests/Helpers/IntegrationTests_MerchantAPI.swift
@@ -53,7 +53,7 @@ class IntegrationTests_MerchantAPI {
         }.resume()
     }
 
-    func generateUAT(completion: @escaping ((String?, Error?) -> Void)) {
+    func generateIDToken(completion: @escaping ((String?, Error?) -> Void)) {
         var components = URLComponents(url: URL(string: "https://ppcp-sample-merchant-sand.herokuapp.com")!, resolvingAgainstBaseURL: false)!
         components.path = "/id-token"
         components.queryItems = [URLQueryItem(name: "countryCode", value: "US")]

--- a/IntegrationTests/Helpers/IntegrationTests_MerchantAPI.swift
+++ b/IntegrationTests/Helpers/IntegrationTests_MerchantAPI.swift
@@ -69,8 +69,8 @@ class IntegrationTests_MerchantAPI {
 
             do {
                 let json = try JSONSerialization.jsonObject(with: data, options: []) as? NSDictionary
-                let uat = json?.value(forKey: "id_token")
-                completion(uat as? String, nil)
+                let idToken = json?.value(forKey: "id_token")
+                completion(idToken as? String, nil)
             } catch (let error) {
                 completion(nil, error)
             }

--- a/IntegrationTests/PYPLClient_IntegrationTests.swift
+++ b/IntegrationTests/PYPLClient_IntegrationTests.swift
@@ -14,15 +14,15 @@ class PYPLClient_IntegrationTests: XCTestCase {
         super.setUp()
 
         // STEP 1 - Fetch ID Token
-        let expectUAT = self.expectation(description: "Fetch Universal Access Token from PPCP sample server")
-        IntegrationTests_MerchantAPI.sharedService.generateUAT { (idToken, error) in
+        let expectIDToken = self.expectation(description: "Fetch ID Token from PPCP sample server")
+        IntegrationTests_MerchantAPI.sharedService.generateIDToken { (idToken, error) in
             guard let idToken = idToken, error == nil else {
                 XCTFail() // without a fresh ID Token, integration tests cannot pass
                 return
             }
 
             self.payPalClient = PYPLClient(idToken: idToken)
-            expectUAT.fulfill()
+            expectIDToken.fulfill()
         }
 
         // STEP 2 - Fetch orderID

--- a/IntegrationTests/PYPLClient_IntegrationTests.swift
+++ b/IntegrationTests/PYPLClient_IntegrationTests.swift
@@ -13,15 +13,15 @@ class PYPLClient_IntegrationTests: XCTestCase {
     override func setUp() {
         super.setUp()
 
-        // STEP 1 - Fetch UAT
+        // STEP 1 - Fetch ID Token
         let expectUAT = self.expectation(description: "Fetch Universal Access Token from PPCP sample server")
-        IntegrationTests_MerchantAPI.sharedService.generateUAT { (uat, error) in
-            guard let uat = uat, error == nil else {
-                XCTFail() // without a fresh UAT, integration tests cannot pass
+        IntegrationTests_MerchantAPI.sharedService.generateUAT { (idToken, error) in
+            guard let idToken = idToken, error == nil else {
+                XCTFail() // without a fresh ID Token, integration tests cannot pass
                 return
             }
 
-            self.payPalClient = PYPLClient(accessToken: uat)
+            self.payPalClient = PYPLClient(idToken: idToken)
             expectUAT.fulfill()
         }
 

--- a/PayPal.xcodeproj/project.pbxproj
+++ b/PayPal.xcodeproj/project.pbxproj
@@ -7,7 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		0D23836B30BE2B7B94BABAC8 /* libPods-Demo.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 0ABDD497A4426C4EA1D96FEB /* libPods-Demo.a */; };
 		42138C7223678B4B00376E80 /* Settings.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 42138C7123678B4B00376E80 /* Settings.bundle */; };
 		423AB53A23EDC9D700B3E06A /* PayPalUATTestHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 423AB53923EDC9D700B3E06A /* PayPalUATTestHelper.swift */; };
 		425B8315236CBDEC006F694D /* BTJSONHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 425B8314236CBDEC006F694D /* BTJSONHelper.swift */; };
@@ -24,6 +23,7 @@
 		42FCAAB0235E32FA00B9BC3E /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42FCAAAF235E32FA00B9BC3E /* AppDelegate.swift */; };
 		42FF386C235E42D000F0CF10 /* PYPLClient_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 42FF386B235E42D000F0CF10 /* PYPLClient_Internal.h */; };
 		49A52AFB23AABF9000F7BC8D /* paypal-validate-request-without-3ds.json in Resources */ = {isa = PBXBuildFile; fileRef = 49A52AFA23AABF9000F7BC8D /* paypal-validate-request-without-3ds.json */; };
+		5D335E0B63E3300621B48B59 /* libPods-Tests-UnitTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E01E94D7E2747CED0136C54D /* libPods-Tests-UnitTests.a */; };
 		80015A2D23566AD6002825E1 /* PYPLCheckoutResult.h in Headers */ = {isa = PBXBuildFile; fileRef = 80015A2B23566AD6002825E1 /* PYPLCheckoutResult.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		80015A2E23566AD6002825E1 /* PYPLCheckoutResult.m in Sources */ = {isa = PBXBuildFile; fileRef = 80015A2C23566AD6002825E1 /* PYPLCheckoutResult.m */; };
 		801DB2F02412EC0B0074426F /* PYPLValidationResult.h in Headers */ = {isa = PBXBuildFile; fileRef = 8026243823578F75005EA84A /* PYPLValidationResult.h */; };
@@ -70,8 +70,8 @@
 		80EA9B0E24607BE100DC0A16 /* PYPLPayPalCheckoutResult.m in Sources */ = {isa = PBXBuildFile; fileRef = 80EA9B0C24607BE100DC0A16 /* PYPLPayPalCheckoutResult.m */; };
 		80EA9B1124607C0100DC0A16 /* PYPLCardCheckoutResult.h in Headers */ = {isa = PBXBuildFile; fileRef = 80EA9B0F24607C0100DC0A16 /* PYPLCardCheckoutResult.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		80EA9B1224607C0100DC0A16 /* PYPLCardCheckoutResult.m in Sources */ = {isa = PBXBuildFile; fileRef = 80EA9B1024607C0100DC0A16 /* PYPLCardCheckoutResult.m */; };
-		9E615AD27349382A095AD30C /* libPods-Tests-IntegrationTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 4EF49265C5BCF6E4343F132C /* libPods-Tests-IntegrationTests.a */; };
-		C76B2427AE1C9F8217AF9F73 /* libPods-Tests-UnitTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 93590F2710D33418A3AE6300 /* libPods-Tests-UnitTests.a */; };
+		98C6592583D3FABABF03F251 /* libPods-Tests-IntegrationTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 36AA28B61CB0A18CF949561B /* libPods-Tests-IntegrationTests.a */; };
+		E191907325792297A9166C99 /* libPods-Demo.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 25202238C69EC03C8A2CAF52 /* libPods-Demo.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -99,8 +99,10 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		0ABDD497A4426C4EA1D96FEB /* libPods-Demo.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Demo.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		1363E5AB41384BCD587424C8 /* Pods-Tests-IntegrationTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tests-IntegrationTests.release.xcconfig"; path = "Target Support Files/Pods-Tests-IntegrationTests/Pods-Tests-IntegrationTests.release.xcconfig"; sourceTree = "<group>"; };
+		0B1B27AFBCDBC981ABAC5E8B /* Pods-Tests-IntegrationTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tests-IntegrationTests.debug.xcconfig"; path = "Target Support Files/Pods-Tests-IntegrationTests/Pods-Tests-IntegrationTests.debug.xcconfig"; sourceTree = "<group>"; };
+		25202238C69EC03C8A2CAF52 /* libPods-Demo.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Demo.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		36AA28B61CB0A18CF949561B /* libPods-Tests-IntegrationTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Tests-IntegrationTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		3B295D4AD3272991342D046A /* Pods-Tests-UnitTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tests-UnitTests.release.xcconfig"; path = "Target Support Files/Pods-Tests-UnitTests/Pods-Tests-UnitTests.release.xcconfig"; sourceTree = "<group>"; };
 		42138C7123678B4B00376E80 /* Settings.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = Settings.bundle; sourceTree = "<group>"; };
 		423AB53923EDC9D700B3E06A /* PayPalUATTestHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PayPalUATTestHelper.swift; sourceTree = "<group>"; };
 		425B8314236CBDEC006F694D /* BTJSONHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTJSONHelper.swift; sourceTree = "<group>"; };
@@ -122,8 +124,8 @@
 		42FCAAAF235E32FA00B9BC3E /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		42FF386B235E42D000F0CF10 /* PYPLClient_Internal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PYPLClient_Internal.h; sourceTree = "<group>"; };
 		49A52AFA23AABF9000F7BC8D /* paypal-validate-request-without-3ds.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "paypal-validate-request-without-3ds.json"; sourceTree = "<group>"; };
-		4B7DE11E0ACAD3E8AADCFC65 /* Pods-Tests-UnitTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tests-UnitTests.release.xcconfig"; path = "Target Support Files/Pods-Tests-UnitTests/Pods-Tests-UnitTests.release.xcconfig"; sourceTree = "<group>"; };
-		4EF49265C5BCF6E4343F132C /* libPods-Tests-IntegrationTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Tests-IntegrationTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		645F1640D0B544F5658D36A4 /* Pods-Tests-UnitTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tests-UnitTests.debug.xcconfig"; path = "Target Support Files/Pods-Tests-UnitTests/Pods-Tests-UnitTests.debug.xcconfig"; sourceTree = "<group>"; };
+		6E918A37ED8DFFB0EBC0A980 /* Pods-Demo.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Demo.debug.xcconfig"; path = "Target Support Files/Pods-Demo/Pods-Demo.debug.xcconfig"; sourceTree = "<group>"; };
 		80015A2B23566AD6002825E1 /* PYPLCheckoutResult.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PYPLCheckoutResult.h; sourceTree = "<group>"; };
 		80015A2C23566AD6002825E1 /* PYPLCheckoutResult.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PYPLCheckoutResult.m; sourceTree = "<group>"; };
 		8026243823578F75005EA84A /* PYPLValidationResult.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PYPLValidationResult.h; sourceTree = "<group>"; };
@@ -180,12 +182,10 @@
 		80EA9B0C24607BE100DC0A16 /* PYPLPayPalCheckoutResult.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PYPLPayPalCheckoutResult.m; sourceTree = "<group>"; };
 		80EA9B0F24607C0100DC0A16 /* PYPLCardCheckoutResult.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PYPLCardCheckoutResult.h; sourceTree = "<group>"; };
 		80EA9B1024607C0100DC0A16 /* PYPLCardCheckoutResult.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PYPLCardCheckoutResult.m; sourceTree = "<group>"; };
-		93590F2710D33418A3AE6300 /* libPods-Tests-UnitTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Tests-UnitTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		936F1E7F6E2A01F97598EFC9 /* Pods-Tests-UnitTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tests-UnitTests.debug.xcconfig"; path = "Target Support Files/Pods-Tests-UnitTests/Pods-Tests-UnitTests.debug.xcconfig"; sourceTree = "<group>"; };
-		93D1244BD06550D58C8C4E17 /* Pods-Demo.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Demo.release.xcconfig"; path = "Target Support Files/Pods-Demo/Pods-Demo.release.xcconfig"; sourceTree = "<group>"; };
 		A0F7C08724339FB20039906E /* Braintree.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Braintree.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		CA0AD77EA7839FE188F1C273 /* Pods-Demo.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Demo.debug.xcconfig"; path = "Target Support Files/Pods-Demo/Pods-Demo.debug.xcconfig"; sourceTree = "<group>"; };
-		E5CC556BF373D22AA504101D /* Pods-Tests-IntegrationTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tests-IntegrationTests.debug.xcconfig"; path = "Target Support Files/Pods-Tests-IntegrationTests/Pods-Tests-IntegrationTests.debug.xcconfig"; sourceTree = "<group>"; };
+		CC9ECFC30CD45CF91869F139 /* Pods-Tests-IntegrationTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tests-IntegrationTests.release.xcconfig"; path = "Target Support Files/Pods-Tests-IntegrationTests/Pods-Tests-IntegrationTests.release.xcconfig"; sourceTree = "<group>"; };
+		E01E94D7E2747CED0136C54D /* libPods-Tests-UnitTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Tests-UnitTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		F9D0DB312B4CA0CDB7518243 /* Pods-Demo.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Demo.release.xcconfig"; path = "Target Support Files/Pods-Demo/Pods-Demo.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -200,7 +200,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				9E615AD27349382A095AD30C /* libPods-Tests-IntegrationTests.a in Frameworks */,
+				98C6592583D3FABABF03F251 /* libPods-Tests-IntegrationTests.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -208,7 +208,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				C76B2427AE1C9F8217AF9F73 /* libPods-Tests-UnitTests.a in Frameworks */,
+				5D335E0B63E3300621B48B59 /* libPods-Tests-UnitTests.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -216,7 +216,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				0D23836B30BE2B7B94BABAC8 /* libPods-Demo.a in Frameworks */,
+				E191907325792297A9166C99 /* libPods-Demo.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -275,12 +275,12 @@
 		6D8747EA22F435AE06F0EF97 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				CA0AD77EA7839FE188F1C273 /* Pods-Demo.debug.xcconfig */,
-				93D1244BD06550D58C8C4E17 /* Pods-Demo.release.xcconfig */,
-				E5CC556BF373D22AA504101D /* Pods-Tests-IntegrationTests.debug.xcconfig */,
-				1363E5AB41384BCD587424C8 /* Pods-Tests-IntegrationTests.release.xcconfig */,
-				936F1E7F6E2A01F97598EFC9 /* Pods-Tests-UnitTests.debug.xcconfig */,
-				4B7DE11E0ACAD3E8AADCFC65 /* Pods-Tests-UnitTests.release.xcconfig */,
+				6E918A37ED8DFFB0EBC0A980 /* Pods-Demo.debug.xcconfig */,
+				F9D0DB312B4CA0CDB7518243 /* Pods-Demo.release.xcconfig */,
+				0B1B27AFBCDBC981ABAC5E8B /* Pods-Tests-IntegrationTests.debug.xcconfig */,
+				CC9ECFC30CD45CF91869F139 /* Pods-Tests-IntegrationTests.release.xcconfig */,
+				645F1640D0B544F5658D36A4 /* Pods-Tests-UnitTests.debug.xcconfig */,
+				3B295D4AD3272991342D046A /* Pods-Tests-UnitTests.release.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -428,9 +428,9 @@
 			isa = PBXGroup;
 			children = (
 				A0F7C08724339FB20039906E /* Braintree.framework */,
-				0ABDD497A4426C4EA1D96FEB /* libPods-Demo.a */,
-				4EF49265C5BCF6E4343F132C /* libPods-Tests-IntegrationTests.a */,
-				93590F2710D33418A3AE6300 /* libPods-Tests-UnitTests.a */,
+				25202238C69EC03C8A2CAF52 /* libPods-Demo.a */,
+				36AA28B61CB0A18CF949561B /* libPods-Tests-IntegrationTests.a */,
+				E01E94D7E2747CED0136C54D /* libPods-Tests-UnitTests.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -483,12 +483,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 804588D9238489F800936C3A /* Build configuration list for PBXNativeTarget "IntegrationTests" */;
 			buildPhases = (
-				20EA48A7AA2C0442B54A7243 /* [CP] Check Pods Manifest.lock */,
+				C4BD2F1AEB7357DCAD1F5038 /* [CP] Check Pods Manifest.lock */,
 				804588CC238489F800936C3A /* Sources */,
 				804588CD238489F800936C3A /* Frameworks */,
 				804588CE238489F800936C3A /* Resources */,
-				0ACA4F784D27F291C7B5C415 /* [CP] Embed Pods Frameworks */,
-				1E008A6598710036C449A274 /* [CP] Copy Pods Resources */,
+				6C5BF52469E297033911A389 /* [CP] Embed Pods Frameworks */,
+				C85AF2AFDB334FA560090A24 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -504,12 +504,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 8066A053235F5026007ACC28 /* Build configuration list for PBXNativeTarget "UnitTests" */;
 			buildPhases = (
-				2DD732D2747BA42316F3D3E1 /* [CP] Check Pods Manifest.lock */,
+				D7D12E23CBEED43E1B57DA73 /* [CP] Check Pods Manifest.lock */,
 				8066A048235F5026007ACC28 /* Sources */,
 				8066A049235F5026007ACC28 /* Frameworks */,
 				8066A04A235F5026007ACC28 /* Resources */,
-				BB1112B2A95A0C5DBE3A64AE /* [CP] Embed Pods Frameworks */,
-				B4C8D933072853C45B038F6D /* [CP] Copy Pods Resources */,
+				A58440ED329CB92BAAFE0E4F /* [CP] Embed Pods Frameworks */,
+				73F0DC2E974C9CA902950A63 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -525,12 +525,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 80BAD28C234531B50050F86C /* Build configuration list for PBXNativeTarget "Demo" */;
 			buildPhases = (
-				580522416E36D234813EEE52 /* [CP] Check Pods Manifest.lock */,
+				E2473743B9698CCC0C6BA08F /* [CP] Check Pods Manifest.lock */,
 				80BAD26F234531B30050F86C /* Sources */,
 				80BAD270234531B30050F86C /* Frameworks */,
 				80BAD271234531B30050F86C /* Resources */,
-				11E68B71813F3C954FAAE4F2 /* [CP] Embed Pods Frameworks */,
-				9BEADE2CCCCEF0BF18A1FF33 /* [CP] Copy Pods Resources */,
+				4271A25211449E704B9927DB /* [CP] Embed Pods Frameworks */,
+				0530BCFA43495C651DCBA320 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -663,24 +663,24 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		0ACA4F784D27F291C7B5C415 /* [CP] Embed Pods Frameworks */ = {
+		0530BCFA43495C651DCBA320 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Tests-IntegrationTests/Pods-Tests-IntegrationTests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+				"${PODS_ROOT}/Target Support Files/Pods-Demo/Pods-Demo-resources-${CONFIGURATION}-input-files.xcfilelist",
 			);
-			name = "[CP] Embed Pods Frameworks";
+			name = "[CP] Copy Pods Resources";
 			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Tests-IntegrationTests/Pods-Tests-IntegrationTests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+				"${PODS_ROOT}/Target Support Files/Pods-Demo/Pods-Demo-resources-${CONFIGURATION}-output-files.xcfilelist",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Tests-IntegrationTests/Pods-Tests-IntegrationTests-frameworks.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Demo/Pods-Demo-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		11E68B71813F3C954FAAE4F2 /* [CP] Embed Pods Frameworks */ = {
+		4271A25211449E704B9927DB /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -697,24 +697,58 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Demo/Pods-Demo-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		1E008A6598710036C449A274 /* [CP] Copy Pods Resources */ = {
+		6C5BF52469E297033911A389 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Tests-IntegrationTests/Pods-Tests-IntegrationTests-resources-${CONFIGURATION}-input-files.xcfilelist",
+				"${PODS_ROOT}/Target Support Files/Pods-Tests-IntegrationTests/Pods-Tests-IntegrationTests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
-			name = "[CP] Copy Pods Resources";
+			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Tests-IntegrationTests/Pods-Tests-IntegrationTests-resources-${CONFIGURATION}-output-files.xcfilelist",
+				"${PODS_ROOT}/Target Support Files/Pods-Tests-IntegrationTests/Pods-Tests-IntegrationTests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Tests-IntegrationTests/Pods-Tests-IntegrationTests-resources.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Tests-IntegrationTests/Pods-Tests-IntegrationTests-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		20EA48A7AA2C0442B54A7243 /* [CP] Check Pods Manifest.lock */ = {
+		73F0DC2E974C9CA902950A63 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Tests-UnitTests/Pods-Tests-UnitTests-resources-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Tests-UnitTests/Pods-Tests-UnitTests-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Tests-UnitTests/Pods-Tests-UnitTests-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		A58440ED329CB92BAAFE0E4F /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Tests-UnitTests/Pods-Tests-UnitTests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Tests-UnitTests/Pods-Tests-UnitTests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Tests-UnitTests/Pods-Tests-UnitTests-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		C4BD2F1AEB7357DCAD1F5038 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -736,7 +770,24 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		2DD732D2747BA42316F3D3E1 /* [CP] Check Pods Manifest.lock */ = {
+		C85AF2AFDB334FA560090A24 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Tests-IntegrationTests/Pods-Tests-IntegrationTests-resources-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Tests-IntegrationTests/Pods-Tests-IntegrationTests-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Tests-IntegrationTests/Pods-Tests-IntegrationTests-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		D7D12E23CBEED43E1B57DA73 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -758,7 +809,7 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		580522416E36D234813EEE52 /* [CP] Check Pods Manifest.lock */ = {
+		E2473743B9698CCC0C6BA08F /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -778,57 +829,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		9BEADE2CCCCEF0BF18A1FF33 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Demo/Pods-Demo-resources-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Copy Pods Resources";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Demo/Pods-Demo-resources-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Demo/Pods-Demo-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		B4C8D933072853C45B038F6D /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Tests-UnitTests/Pods-Tests-UnitTests-resources-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Copy Pods Resources";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Tests-UnitTests/Pods-Tests-UnitTests-resources-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Tests-UnitTests/Pods-Tests-UnitTests-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		BB1112B2A95A0C5DBE3A64AE /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Tests-UnitTests/Pods-Tests-UnitTests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Tests-UnitTests/Pods-Tests-UnitTests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Tests-UnitTests/Pods-Tests-UnitTests-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -984,7 +984,7 @@
 		};
 		804588D7238489F800936C3A /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = E5CC556BF373D22AA504101D /* Pods-Tests-IntegrationTests.debug.xcconfig */;
+			baseConfigurationReference = 0B1B27AFBCDBC981ABAC5E8B /* Pods-Tests-IntegrationTests.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
@@ -1010,7 +1010,7 @@
 		};
 		804588D8238489F800936C3A /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 1363E5AB41384BCD587424C8 /* Pods-Tests-IntegrationTests.release.xcconfig */;
+			baseConfigurationReference = CC9ECFC30CD45CF91869F139 /* Pods-Tests-IntegrationTests.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
@@ -1035,7 +1035,7 @@
 		};
 		8066A054235F5026007ACC28 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 936F1E7F6E2A01F97598EFC9 /* Pods-Tests-UnitTests.debug.xcconfig */;
+			baseConfigurationReference = 645F1640D0B544F5658D36A4 /* Pods-Tests-UnitTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -1060,7 +1060,7 @@
 		};
 		8066A055235F5026007ACC28 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 4B7DE11E0ACAD3E8AADCFC65 /* Pods-Tests-UnitTests.release.xcconfig */;
+			baseConfigurationReference = 3B295D4AD3272991342D046A /* Pods-Tests-UnitTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -1198,7 +1198,7 @@
 		};
 		80BAD28D234531B50050F86C /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = CA0AD77EA7839FE188F1C273 /* Pods-Demo.debug.xcconfig */;
+			baseConfigurationReference = 6E918A37ED8DFFB0EBC0A980 /* Pods-Demo.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = YES;
@@ -1222,7 +1222,7 @@
 		};
 		80BAD28E234531B50050F86C /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 93D1244BD06550D58C8C4E17 /* Pods-Demo.release.xcconfig */;
+			baseConfigurationReference = F9D0DB312B4CA0CDB7518243 /* Pods-Demo.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = YES;

--- a/PayPal.xcodeproj/project.pbxproj
+++ b/PayPal.xcodeproj/project.pbxproj
@@ -7,8 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		066191F1609E34AC9A31F9CB /* libPods-Tests-UnitTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B38921D6E50667E09C2B3314 /* libPods-Tests-UnitTests.a */; };
+		13CCF51F6C2917C4E27AE847 /* libPods-Tests-IntegrationTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 89875292FB148893E0050526 /* libPods-Tests-IntegrationTests.a */; };
 		42138C7223678B4B00376E80 /* Settings.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 42138C7123678B4B00376E80 /* Settings.bundle */; };
-		423AB53A23EDC9D700B3E06A /* PayPalUATTestHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 423AB53923EDC9D700B3E06A /* PayPalUATTestHelper.swift */; };
+		423AB53A23EDC9D700B3E06A /* PayPalIDTokenTestHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 423AB53923EDC9D700B3E06A /* PayPalIDTokenTestHelper.swift */; };
 		425B8315236CBDEC006F694D /* BTJSONHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 425B8314236CBDEC006F694D /* BTJSONHelper.swift */; };
 		425B831B236CBE8C006F694D /* paypal-validate-request-with-3ds.json in Resources */ = {isa = PBXBuildFile; fileRef = 425B831A236CBE8C006F694D /* paypal-validate-request-with-3ds.json */; };
 		425B831F236CCC99006F694D /* paypal-validation-response-without-contingency.json in Resources */ = {isa = PBXBuildFile; fileRef = 425B831E236CCC99006F694D /* paypal-validation-response-without-contingency.json */; };
@@ -23,7 +25,6 @@
 		42FCAAB0235E32FA00B9BC3E /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42FCAAAF235E32FA00B9BC3E /* AppDelegate.swift */; };
 		42FF386C235E42D000F0CF10 /* PYPLClient_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 42FF386B235E42D000F0CF10 /* PYPLClient_Internal.h */; };
 		49A52AFB23AABF9000F7BC8D /* paypal-validate-request-without-3ds.json in Resources */ = {isa = PBXBuildFile; fileRef = 49A52AFA23AABF9000F7BC8D /* paypal-validate-request-without-3ds.json */; };
-		5D335E0B63E3300621B48B59 /* libPods-Tests-UnitTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E01E94D7E2747CED0136C54D /* libPods-Tests-UnitTests.a */; };
 		80015A2D23566AD6002825E1 /* PYPLCheckoutResult.h in Headers */ = {isa = PBXBuildFile; fileRef = 80015A2B23566AD6002825E1 /* PYPLCheckoutResult.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		80015A2E23566AD6002825E1 /* PYPLCheckoutResult.m in Sources */ = {isa = PBXBuildFile; fileRef = 80015A2C23566AD6002825E1 /* PYPLCheckoutResult.m */; };
 		801DB2F02412EC0B0074426F /* PYPLValidationResult.h in Headers */ = {isa = PBXBuildFile; fileRef = 8026243823578F75005EA84A /* PYPLValidationResult.h */; };
@@ -70,8 +71,7 @@
 		80EA9B0E24607BE100DC0A16 /* PYPLPayPalCheckoutResult.m in Sources */ = {isa = PBXBuildFile; fileRef = 80EA9B0C24607BE100DC0A16 /* PYPLPayPalCheckoutResult.m */; };
 		80EA9B1124607C0100DC0A16 /* PYPLCardCheckoutResult.h in Headers */ = {isa = PBXBuildFile; fileRef = 80EA9B0F24607C0100DC0A16 /* PYPLCardCheckoutResult.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		80EA9B1224607C0100DC0A16 /* PYPLCardCheckoutResult.m in Sources */ = {isa = PBXBuildFile; fileRef = 80EA9B1024607C0100DC0A16 /* PYPLCardCheckoutResult.m */; };
-		98C6592583D3FABABF03F251 /* libPods-Tests-IntegrationTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 36AA28B61CB0A18CF949561B /* libPods-Tests-IntegrationTests.a */; };
-		E191907325792297A9166C99 /* libPods-Demo.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 25202238C69EC03C8A2CAF52 /* libPods-Demo.a */; };
+		BF071FF1A75208674A4B72A2 /* libPods-Demo.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 9069DB84676B6BEC98D641D6 /* libPods-Demo.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -99,12 +99,13 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		0B1B27AFBCDBC981ABAC5E8B /* Pods-Tests-IntegrationTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tests-IntegrationTests.debug.xcconfig"; path = "Target Support Files/Pods-Tests-IntegrationTests/Pods-Tests-IntegrationTests.debug.xcconfig"; sourceTree = "<group>"; };
-		25202238C69EC03C8A2CAF52 /* libPods-Demo.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Demo.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		36AA28B61CB0A18CF949561B /* libPods-Tests-IntegrationTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Tests-IntegrationTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		3B295D4AD3272991342D046A /* Pods-Tests-UnitTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tests-UnitTests.release.xcconfig"; path = "Target Support Files/Pods-Tests-UnitTests/Pods-Tests-UnitTests.release.xcconfig"; sourceTree = "<group>"; };
+		09FA0EDA14FBA732A8E447EE /* Pods-Tests-UnitTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tests-UnitTests.debug.xcconfig"; path = "Target Support Files/Pods-Tests-UnitTests/Pods-Tests-UnitTests.debug.xcconfig"; sourceTree = "<group>"; };
+		11F70DCFB22251923CA9D4BB /* Pods-Tests-UnitTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tests-UnitTests.release.xcconfig"; path = "Target Support Files/Pods-Tests-UnitTests/Pods-Tests-UnitTests.release.xcconfig"; sourceTree = "<group>"; };
+		13926A9C60CC19E4B79984F7 /* Pods-Tests-IntegrationTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tests-IntegrationTests.debug.xcconfig"; path = "Target Support Files/Pods-Tests-IntegrationTests/Pods-Tests-IntegrationTests.debug.xcconfig"; sourceTree = "<group>"; };
+		28404A6F0FF12D28278F133E /* Pods-Demo.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Demo.debug.xcconfig"; path = "Target Support Files/Pods-Demo/Pods-Demo.debug.xcconfig"; sourceTree = "<group>"; };
+		3B389B68C08CCFD723BDC174 /* Pods-Demo.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Demo.release.xcconfig"; path = "Target Support Files/Pods-Demo/Pods-Demo.release.xcconfig"; sourceTree = "<group>"; };
 		42138C7123678B4B00376E80 /* Settings.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = Settings.bundle; sourceTree = "<group>"; };
-		423AB53923EDC9D700B3E06A /* PayPalUATTestHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PayPalUATTestHelper.swift; sourceTree = "<group>"; };
+		423AB53923EDC9D700B3E06A /* PayPalIDTokenTestHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PayPalIDTokenTestHelper.swift; sourceTree = "<group>"; };
 		425B8314236CBDEC006F694D /* BTJSONHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTJSONHelper.swift; sourceTree = "<group>"; };
 		425B831A236CBE8C006F694D /* paypal-validate-request-with-3ds.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "paypal-validate-request-with-3ds.json"; sourceTree = "<group>"; };
 		425B831E236CCC99006F694D /* paypal-validation-response-without-contingency.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "paypal-validation-response-without-contingency.json"; sourceTree = "<group>"; };
@@ -124,8 +125,6 @@
 		42FCAAAF235E32FA00B9BC3E /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		42FF386B235E42D000F0CF10 /* PYPLClient_Internal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PYPLClient_Internal.h; sourceTree = "<group>"; };
 		49A52AFA23AABF9000F7BC8D /* paypal-validate-request-without-3ds.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "paypal-validate-request-without-3ds.json"; sourceTree = "<group>"; };
-		645F1640D0B544F5658D36A4 /* Pods-Tests-UnitTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tests-UnitTests.debug.xcconfig"; path = "Target Support Files/Pods-Tests-UnitTests/Pods-Tests-UnitTests.debug.xcconfig"; sourceTree = "<group>"; };
-		6E918A37ED8DFFB0EBC0A980 /* Pods-Demo.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Demo.debug.xcconfig"; path = "Target Support Files/Pods-Demo/Pods-Demo.debug.xcconfig"; sourceTree = "<group>"; };
 		80015A2B23566AD6002825E1 /* PYPLCheckoutResult.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PYPLCheckoutResult.h; sourceTree = "<group>"; };
 		80015A2C23566AD6002825E1 /* PYPLCheckoutResult.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PYPLCheckoutResult.m; sourceTree = "<group>"; };
 		8026243823578F75005EA84A /* PYPLValidationResult.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PYPLValidationResult.h; sourceTree = "<group>"; };
@@ -182,10 +181,11 @@
 		80EA9B0C24607BE100DC0A16 /* PYPLPayPalCheckoutResult.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PYPLPayPalCheckoutResult.m; sourceTree = "<group>"; };
 		80EA9B0F24607C0100DC0A16 /* PYPLCardCheckoutResult.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PYPLCardCheckoutResult.h; sourceTree = "<group>"; };
 		80EA9B1024607C0100DC0A16 /* PYPLCardCheckoutResult.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PYPLCardCheckoutResult.m; sourceTree = "<group>"; };
+		89875292FB148893E0050526 /* libPods-Tests-IntegrationTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Tests-IntegrationTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		9069DB84676B6BEC98D641D6 /* libPods-Demo.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Demo.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		A0F7C08724339FB20039906E /* Braintree.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Braintree.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		CC9ECFC30CD45CF91869F139 /* Pods-Tests-IntegrationTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tests-IntegrationTests.release.xcconfig"; path = "Target Support Files/Pods-Tests-IntegrationTests/Pods-Tests-IntegrationTests.release.xcconfig"; sourceTree = "<group>"; };
-		E01E94D7E2747CED0136C54D /* libPods-Tests-UnitTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Tests-UnitTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		F9D0DB312B4CA0CDB7518243 /* Pods-Demo.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Demo.release.xcconfig"; path = "Target Support Files/Pods-Demo/Pods-Demo.release.xcconfig"; sourceTree = "<group>"; };
+		B38921D6E50667E09C2B3314 /* libPods-Tests-UnitTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Tests-UnitTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		FFD1CDCE05BB236202F15D4E /* Pods-Tests-IntegrationTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tests-IntegrationTests.release.xcconfig"; path = "Target Support Files/Pods-Tests-IntegrationTests/Pods-Tests-IntegrationTests.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -200,7 +200,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				98C6592583D3FABABF03F251 /* libPods-Tests-IntegrationTests.a in Frameworks */,
+				13CCF51F6C2917C4E27AE847 /* libPods-Tests-IntegrationTests.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -208,7 +208,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				5D335E0B63E3300621B48B59 /* libPods-Tests-UnitTests.a in Frameworks */,
+				066191F1609E34AC9A31F9CB /* libPods-Tests-UnitTests.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -216,7 +216,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E191907325792297A9166C99 /* libPods-Demo.a in Frameworks */,
+				BF071FF1A75208674A4B72A2 /* libPods-Demo.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -267,7 +267,7 @@
 				809E0A8E23C7D7AD00D9A2C0 /* MockPPDataCollector.swift */,
 				8077518C236A3D08001B61BE /* MockURLSession.swift */,
 				42986C05235E4B9F00D31176 /* MockViewControllerPresentingDelegate.swift */,
-				423AB53923EDC9D700B3E06A /* PayPalUATTestHelper.swift */,
+				423AB53923EDC9D700B3E06A /* PayPalIDTokenTestHelper.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -275,12 +275,12 @@
 		6D8747EA22F435AE06F0EF97 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				6E918A37ED8DFFB0EBC0A980 /* Pods-Demo.debug.xcconfig */,
-				F9D0DB312B4CA0CDB7518243 /* Pods-Demo.release.xcconfig */,
-				0B1B27AFBCDBC981ABAC5E8B /* Pods-Tests-IntegrationTests.debug.xcconfig */,
-				CC9ECFC30CD45CF91869F139 /* Pods-Tests-IntegrationTests.release.xcconfig */,
-				645F1640D0B544F5658D36A4 /* Pods-Tests-UnitTests.debug.xcconfig */,
-				3B295D4AD3272991342D046A /* Pods-Tests-UnitTests.release.xcconfig */,
+				28404A6F0FF12D28278F133E /* Pods-Demo.debug.xcconfig */,
+				3B389B68C08CCFD723BDC174 /* Pods-Demo.release.xcconfig */,
+				13926A9C60CC19E4B79984F7 /* Pods-Tests-IntegrationTests.debug.xcconfig */,
+				FFD1CDCE05BB236202F15D4E /* Pods-Tests-IntegrationTests.release.xcconfig */,
+				09FA0EDA14FBA732A8E447EE /* Pods-Tests-UnitTests.debug.xcconfig */,
+				11F70DCFB22251923CA9D4BB /* Pods-Tests-UnitTests.release.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -428,9 +428,9 @@
 			isa = PBXGroup;
 			children = (
 				A0F7C08724339FB20039906E /* Braintree.framework */,
-				25202238C69EC03C8A2CAF52 /* libPods-Demo.a */,
-				36AA28B61CB0A18CF949561B /* libPods-Tests-IntegrationTests.a */,
-				E01E94D7E2747CED0136C54D /* libPods-Tests-UnitTests.a */,
+				9069DB84676B6BEC98D641D6 /* libPods-Demo.a */,
+				89875292FB148893E0050526 /* libPods-Tests-IntegrationTests.a */,
+				B38921D6E50667E09C2B3314 /* libPods-Tests-UnitTests.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -483,12 +483,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 804588D9238489F800936C3A /* Build configuration list for PBXNativeTarget "IntegrationTests" */;
 			buildPhases = (
-				C4BD2F1AEB7357DCAD1F5038 /* [CP] Check Pods Manifest.lock */,
+				CB213346FDC2F8DFD0AB0608 /* [CP] Check Pods Manifest.lock */,
 				804588CC238489F800936C3A /* Sources */,
 				804588CD238489F800936C3A /* Frameworks */,
 				804588CE238489F800936C3A /* Resources */,
-				6C5BF52469E297033911A389 /* [CP] Embed Pods Frameworks */,
-				C85AF2AFDB334FA560090A24 /* [CP] Copy Pods Resources */,
+				B8FEAA027B33280FFAA3D950 /* [CP] Embed Pods Frameworks */,
+				074B125C41ED517D96B71014 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -504,12 +504,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 8066A053235F5026007ACC28 /* Build configuration list for PBXNativeTarget "UnitTests" */;
 			buildPhases = (
-				D7D12E23CBEED43E1B57DA73 /* [CP] Check Pods Manifest.lock */,
+				4E3625A8C16134FA18818B94 /* [CP] Check Pods Manifest.lock */,
 				8066A048235F5026007ACC28 /* Sources */,
 				8066A049235F5026007ACC28 /* Frameworks */,
 				8066A04A235F5026007ACC28 /* Resources */,
-				A58440ED329CB92BAAFE0E4F /* [CP] Embed Pods Frameworks */,
-				73F0DC2E974C9CA902950A63 /* [CP] Copy Pods Resources */,
+				387781419A5B828294A8C490 /* [CP] Embed Pods Frameworks */,
+				ED8EAC5CA57BC423547EA41F /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -525,12 +525,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 80BAD28C234531B50050F86C /* Build configuration list for PBXNativeTarget "Demo" */;
 			buildPhases = (
-				E2473743B9698CCC0C6BA08F /* [CP] Check Pods Manifest.lock */,
+				264302D4B31DBA17076E2DEB /* [CP] Check Pods Manifest.lock */,
 				80BAD26F234531B30050F86C /* Sources */,
 				80BAD270234531B30050F86C /* Frameworks */,
 				80BAD271234531B30050F86C /* Resources */,
-				4271A25211449E704B9927DB /* [CP] Embed Pods Frameworks */,
-				0530BCFA43495C651DCBA320 /* [CP] Copy Pods Resources */,
+				A4BBFB364087CDE935B61A7B /* [CP] Embed Pods Frameworks */,
+				D7CC173867E6F44199C47259 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -663,114 +663,7 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		0530BCFA43495C651DCBA320 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Demo/Pods-Demo-resources-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Copy Pods Resources";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Demo/Pods-Demo-resources-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Demo/Pods-Demo-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		4271A25211449E704B9927DB /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Demo/Pods-Demo-frameworks-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Demo/Pods-Demo-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Demo/Pods-Demo-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		6C5BF52469E297033911A389 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Tests-IntegrationTests/Pods-Tests-IntegrationTests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Tests-IntegrationTests/Pods-Tests-IntegrationTests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Tests-IntegrationTests/Pods-Tests-IntegrationTests-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		73F0DC2E974C9CA902950A63 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Tests-UnitTests/Pods-Tests-UnitTests-resources-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Copy Pods Resources";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Tests-UnitTests/Pods-Tests-UnitTests-resources-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Tests-UnitTests/Pods-Tests-UnitTests-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		A58440ED329CB92BAAFE0E4F /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Tests-UnitTests/Pods-Tests-UnitTests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Tests-UnitTests/Pods-Tests-UnitTests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Tests-UnitTests/Pods-Tests-UnitTests-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		C4BD2F1AEB7357DCAD1F5038 /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-Tests-IntegrationTests-checkManifestLockResult.txt",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		C85AF2AFDB334FA560090A24 /* [CP] Copy Pods Resources */ = {
+		074B125C41ED517D96B71014 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -787,7 +680,46 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Tests-IntegrationTests/Pods-Tests-IntegrationTests-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		D7D12E23CBEED43E1B57DA73 /* [CP] Check Pods Manifest.lock */ = {
+		264302D4B31DBA17076E2DEB /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Demo-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		387781419A5B828294A8C490 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Tests-UnitTests/Pods-Tests-UnitTests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Tests-UnitTests/Pods-Tests-UnitTests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Tests-UnitTests/Pods-Tests-UnitTests-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		4E3625A8C16134FA18818B94 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -809,7 +741,41 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		E2473743B9698CCC0C6BA08F /* [CP] Check Pods Manifest.lock */ = {
+		A4BBFB364087CDE935B61A7B /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Demo/Pods-Demo-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Demo/Pods-Demo-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Demo/Pods-Demo-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		B8FEAA027B33280FFAA3D950 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Tests-IntegrationTests/Pods-Tests-IntegrationTests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Tests-IntegrationTests/Pods-Tests-IntegrationTests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Tests-IntegrationTests/Pods-Tests-IntegrationTests-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		CB213346FDC2F8DFD0AB0608 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -824,11 +790,45 @@
 			outputFileListPaths = (
 			);
 			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-Demo-checkManifestLockResult.txt",
+				"$(DERIVED_FILE_DIR)/Pods-Tests-IntegrationTests-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		D7CC173867E6F44199C47259 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Demo/Pods-Demo-resources-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Demo/Pods-Demo-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Demo/Pods-Demo-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		ED8EAC5CA57BC423547EA41F /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Tests-UnitTests/Pods-Tests-UnitTests-resources-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Tests-UnitTests/Pods-Tests-UnitTests-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Tests-UnitTests/Pods-Tests-UnitTests-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -865,7 +865,7 @@
 				8066A05B235F51EF007ACC28 /* MockApplePayClient.swift in Sources */,
 				803F7C2923E8BC8900F9D70A /* PYPLPayPalPaymentFlowRequest_Tests.swift in Sources */,
 				4276306D2360E91B00A8734E /* MockCardClient.swift in Sources */,
-				423AB53A23EDC9D700B3E06A /* PayPalUATTestHelper.swift in Sources */,
+				423AB53A23EDC9D700B3E06A /* PayPalIDTokenTestHelper.swift in Sources */,
 				808B1E3D24589CF700D4CDA7 /* MockPKPayment.swift in Sources */,
 				425B8325236CEBF7006F694D /* MockPaymentFlowDriverDelegate.swift in Sources */,
 				803F7C2B23E8BF5D00F9D70A /* MockBTAPIClient.swift in Sources */,
@@ -984,7 +984,7 @@
 		};
 		804588D7238489F800936C3A /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 0B1B27AFBCDBC981ABAC5E8B /* Pods-Tests-IntegrationTests.debug.xcconfig */;
+			baseConfigurationReference = 13926A9C60CC19E4B79984F7 /* Pods-Tests-IntegrationTests.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
@@ -1010,7 +1010,7 @@
 		};
 		804588D8238489F800936C3A /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = CC9ECFC30CD45CF91869F139 /* Pods-Tests-IntegrationTests.release.xcconfig */;
+			baseConfigurationReference = FFD1CDCE05BB236202F15D4E /* Pods-Tests-IntegrationTests.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
@@ -1035,7 +1035,7 @@
 		};
 		8066A054235F5026007ACC28 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 645F1640D0B544F5658D36A4 /* Pods-Tests-UnitTests.debug.xcconfig */;
+			baseConfigurationReference = 09FA0EDA14FBA732A8E447EE /* Pods-Tests-UnitTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -1060,7 +1060,7 @@
 		};
 		8066A055235F5026007ACC28 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 3B295D4AD3272991342D046A /* Pods-Tests-UnitTests.release.xcconfig */;
+			baseConfigurationReference = 11F70DCFB22251923CA9D4BB /* Pods-Tests-UnitTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -1198,7 +1198,7 @@
 		};
 		80BAD28D234531B50050F86C /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 6E918A37ED8DFFB0EBC0A980 /* Pods-Demo.debug.xcconfig */;
+			baseConfigurationReference = 28404A6F0FF12D28278F133E /* Pods-Demo.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = YES;
@@ -1222,7 +1222,7 @@
 		};
 		80BAD28E234531B50050F86C /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = F9D0DB312B4CA0CDB7518243 /* Pods-Demo.release.xcconfig */;
+			baseConfigurationReference = 3B389B68C08CCFD723BDC174 /* Pods-Demo.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = YES;

--- a/PayPal/PYPLAPIClient.h
+++ b/PayPal/PYPLAPIClient.h
@@ -19,7 +19,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong) NSURLSession *urlSession;
 @property (nonatomic, strong) BTAPIClient *braintreeAPIClient;
 
-- (nullable instancetype)initWithAccessToken:(NSString *)accessToken;
+- (nullable instancetype)initWithIDToken:(NSString *)idToken;
 
 - (void)validatePaymentMethod:(BTPaymentMethodNonce *)paymentMethod
                    forOrderId:(NSString *)orderId

--- a/PayPal/PYPLAPIClient.m
+++ b/PayPal/PYPLAPIClient.m
@@ -6,21 +6,21 @@ NSString * const PYPLAPIClientErrorDomain = @"com.braintreepayments.PYPLAPIClien
 
 @interface PYPLAPIClient()
 
-@property (nonatomic, strong) BTPayPalUAT *payPalUAT;
+@property (nonatomic, strong) BTPayPalIDToken *payPalIDToken;
 
 @end
 
 @implementation PYPLAPIClient
 
-- (nullable instancetype)initWithAccessToken:(NSString *)accessToken {
+- (nullable instancetype)initWithIDToken:(NSString *)idToken {
     if (self = [super init]) {
         _urlSession = NSURLSession.sharedSession;
-        _braintreeAPIClient = [[BTAPIClient alloc] initWithAuthorization:accessToken];
+        _braintreeAPIClient = [[BTAPIClient alloc] initWithAuthorization:idToken];
         
         NSError *error;
-        _payPalUAT = [[BTPayPalUAT alloc] initWithUATString:accessToken error:&error];
-        if (error || !_payPalUAT) {
-            NSLog(@"[PayPalSDK] %@", error.localizedDescription ?: @"Error initializing PayPal UAT");
+        _payPalIDToken = [[BTPayPalIDToken alloc] initWithIDTokenString:idToken error:&error];
+        if (error || !_payPalIDToken) {
+            NSLog(@"[PayPalSDK] %@", error.localizedDescription ?: @"Error initializing PayPal ID Token");
             return nil;
         }
     }
@@ -33,7 +33,7 @@ NSString * const PYPLAPIClientErrorDomain = @"com.braintreepayments.PYPLAPIClien
                       with3DS:(BOOL)isThreeDSecureRequired
                    completion:(void (^)(PYPLValidationResult * _Nullable result, NSError * _Nullable error))completion {
     
-    NSString *urlString = [NSString stringWithFormat:@"%@/v2/checkout/orders/%@/validate-payment-method", self.payPalUAT.basePayPalURL, orderId];
+    NSString *urlString = [NSString stringWithFormat:@"%@/v2/checkout/orders/%@/validate-payment-method", self.payPalIDToken.basePayPalURL, orderId];
     NSError *createRequestError;
     
     NSURLRequest *urlRequest = [self createValidateURLRequest:[NSURL URLWithString:urlString]
@@ -94,7 +94,7 @@ NSString * const PYPLAPIClientErrorDomain = @"com.braintreepayments.PYPLAPIClien
                                               error:(NSError **)error {
     NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:url];
     request.HTTPMethod = @"POST";
-    [request setValue:[NSString stringWithFormat:@"Bearer %@", self.payPalUAT.token] forHTTPHeaderField:@"Authorization"];
+    [request setValue:[NSString stringWithFormat:@"Bearer %@", self.payPalIDToken.token] forHTTPHeaderField:@"Authorization"];
     [request setValue:@"application/json" forHTTPHeaderField:@"Content-Type"];
     
     NSDictionary *body = [self constructValidatePayload:paymentMethodNonce with3DS:isThreeDSecureRequired];

--- a/PayPal/PYPLClient.m
+++ b/PayPal/PYPLClient.m
@@ -27,17 +27,17 @@ static NSString *PayPalDataCollectorClassString = @"PPDataCollector";
     [PayPalDataCollectorClass clientMetadataID:_orderId];
 }
 
-- (nullable instancetype)initWithAccessToken:(NSString *)accessToken {
+- (nullable instancetype)initWithIDToken:(NSString *)idToken {
     self = [super init];
     if (self) {
         NSError *error;
-        _payPalUAT = [[BTPayPalUAT alloc] initWithUATString:accessToken error:&error];
-        if (error || !_payPalUAT) {
-            NSLog(@"[PayPalSDK]: Error initializing PayPal UAT. Error code: %ld", (long) error.code);
+        _payPalIDToken = [[BTPayPalIDToken alloc] initWithIDTokenString:idToken error:&error];
+        if (error || !_payPalIDToken) {
+            NSLog(@"[PayPalSDK]: Error initializing PayPal ID Token. Error code: %ld", (long) error.code);
             return nil;
         }
 
-        _braintreeAPIClient = [[BTAPIClient alloc] initWithAuthorization:accessToken];
+        _braintreeAPIClient = [[BTAPIClient alloc] initWithAuthorization:idToken];
         if (!_braintreeAPIClient) {
             return nil;
         }
@@ -45,7 +45,7 @@ static NSString *PayPalDataCollectorClassString = @"PPDataCollector";
         _applePayClient = [[BTApplePayClient alloc] initWithAPIClient:_braintreeAPIClient];
         _cardClient = [[BTCardClient alloc] initWithAPIClient:_braintreeAPIClient];
         _paymentFlowDriver = [[BTPaymentFlowDriver alloc] initWithAPIClient:_braintreeAPIClient];
-        _payPalAPIClient = [[PYPLAPIClient alloc] initWithAccessToken:accessToken];
+        _payPalAPIClient = [[PYPLAPIClient alloc] initWithIDToken:idToken];
     }
 
     return self;
@@ -119,11 +119,11 @@ static NSString *PayPalDataCollectorClassString = @"PPDataCollector";
     [self.braintreeAPIClient sendAnalyticsEvent:@"ios.paypal-sdk.paypal-checkout.started"];
 
     NSString *baseURL;
-    if (self.payPalUAT.environment == BTPayPalUATEnvironmentProd) {
+    if (self.payPalIDToken.environment == BTPayPalIDTokenEnvironmentProd) {
         baseURL = @"https://www.paypal.com";
-    } else if (self.payPalUAT.environment == BTPayPalUATEnvironmentSand) {
+    } else if (self.payPalIDToken.environment == BTPayPalIDTokenEnvironmentSand) {
         baseURL = @"https://www.sandbox.paypal.com";
-    } else if (self.payPalUAT.environment == BTPayPalUATEnvironmentStage) {
+    } else if (self.payPalIDToken.environment == BTPayPalIDTokenEnvironmentStage) {
         baseURL = @"https://www.msmaster.qa.paypal.com";
     }
 

--- a/PayPal/PYPLClient_Internal.h
+++ b/PayPal/PYPLClient_Internal.h
@@ -10,7 +10,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong) BTCardClient *cardClient;
 @property (nonatomic, strong) BTPaymentFlowDriver *paymentFlowDriver;
 @property (nonatomic, strong) BTAPIClient *braintreeAPIClient;
-@property (nonatomic, strong) BTPayPalUAT *payPalUAT;
+@property (nonatomic, strong) BTPayPalIDToken *payPalIDToken;
 
 /**
  The `PPDataCollector` class, exposed internally for injecting test doubles for unit tests

--- a/PayPal/Public/PYPLClient.h
+++ b/PayPal/Public/PYPLClient.h
@@ -53,10 +53,10 @@ typedef void (^PYPLApplePayResultHandler)(BOOL success);
 /**
  Initializes a new `PYPLClient`.
 
- @param accessToken A valid PayPal UAT.
+ @param idToken A valid PayPal ID Token.
  @return A PYPLClient, or `nil` if initialization failed.
  */
-- (nullable instancetype)initWithAccessToken:(NSString *)accessToken;
+- (nullable instancetype)initWithIDToken:(NSString *)idToken;
 
 /**
  @brief Initiates the Card checkout flow.

--- a/Podfile
+++ b/Podfile
@@ -5,13 +5,13 @@ inhibit_all_warnings!
 
 target 'Demo' do
   pod 'PayPal', :path => './'
-  pod 'Braintree', :git => 'https://github.com/braintree/braintree_ios.git', :branch => 'pp-auth-support'
+  pod 'Braintree', :git => 'https://github.com/braintree/braintree_ios.git', :branch => 'fpti-and-id-token-support'
   pod 'InAppSettingsKit'
 end
 
 abstract_target 'Tests' do
   pod 'PayPal', :path => './'
-  pod 'Braintree', :git => 'https://github.com/braintree/braintree_ios.git', :branch => 'pp-auth-support'
+  pod 'Braintree', :git => 'https://github.com/braintree/braintree_ios.git', :branch => 'fpti-and-id-token-support'
 
   target 'UnitTests'
   target 'IntegrationTests'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -51,7 +51,7 @@ EXTERNAL SOURCES:
 
 CHECKOUT OPTIONS:
   Braintree:
-    :commit: 9020fc9a2f6d1c211f0db582301760a69b4a7ce8
+    :commit: a8414199c121fff31c5b7ba49f002eee0f29912b
     :git: https://github.com/braintree/braintree_ios.git
 
 SPEC CHECKSUMS:

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -34,7 +34,7 @@ PODS:
     - Braintree/PaymentFlow
 
 DEPENDENCIES:
-  - Braintree (from `https://github.com/braintree/braintree_ios.git`, branch `pp-auth-support`)
+  - Braintree (from `https://github.com/braintree/braintree_ios.git`, branch `fpti-and-id-token-support`)
   - InAppSettingsKit
   - PayPal (from `./`)
 
@@ -44,21 +44,21 @@ SPEC REPOS:
 
 EXTERNAL SOURCES:
   Braintree:
-    :branch: pp-auth-support
+    :branch: fpti-and-id-token-support
     :git: https://github.com/braintree/braintree_ios.git
   PayPal:
     :path: "./"
 
 CHECKOUT OPTIONS:
   Braintree:
-    :commit: 72597f1d50766da02afa0705037591432fd9a25f
+    :commit: 9020fc9a2f6d1c211f0db582301760a69b4a7ce8
     :git: https://github.com/braintree/braintree_ios.git
 
 SPEC CHECKSUMS:
-  Braintree: 48154e70306eb3e6c81eaa87bbc5c5988c0d2784
+  Braintree: 6ace63d4eb5e26a55cdc660d19d98bdb1d8bf885
   InAppSettingsKit: 4890a44f9df7a1742c632920f0ea939cbeb29ea2
   PayPal: 369e3bdef937ad496d48c1c9c588148fcbb11627
 
-PODFILE CHECKSUM: 52e521028c2a49307f1f5d8e74a8bd35ad78fc25
+PODFILE CHECKSUM: 5ea79210f5d7edc875c2dd933a3c110ee07de1b4
 
 COCOAPODS: 1.9.3

--- a/UITests/CardCheckout_UITests.swift
+++ b/UITests/CardCheckout_UITests.swift
@@ -1,6 +1,6 @@
 import XCTest
 
-// NOTE: These tests fetch UAT and orderID from the sample merchant server https://ppcp-sample-merchant-sand.herokuapp.com
+// NOTE: These tests fetch ID Token and orderID from the sample merchant server https://ppcp-sample-merchant-sand.herokuapp.com
 
 class CardCheckout_UITests: XCTestCase {
     var app: XCUIApplication!
@@ -10,9 +10,9 @@ class CardCheckout_UITests: XCTestCase {
         app.launchArguments.append("-Capture")
         app.launch()
 
-        // wait for PP UAT
-        let uatExistsPredicate = NSPredicate(format: "label LIKE 'Fetched UAT:*'")
-        waitForElementToAppear(app.staticTexts.containing(uatExistsPredicate).element(boundBy: 0))
+        // wait for PP ID Token
+        let idTokenExistsPredicate = NSPredicate(format: "label LIKE 'Fetched ID Token:*'")
+        waitForElementToAppear(app.staticTexts.containing(idTokenExistsPredicate).element(boundBy: 0))
 
         // tap Create Order button
         app.buttons["Create Order"].tap()
@@ -57,9 +57,9 @@ class CardCheckout_UITests: XCTestCase {
         app.launchArguments.append("-Authorize")
         app.launch()
 
-        // wait for PP UAT
-        let uatExistsPredicate = NSPredicate(format: "label LIKE 'Fetched UAT:*'")
-        waitForElementToAppear(app.staticTexts.containing(uatExistsPredicate).element(boundBy: 0))
+        // wait for PP ID Token
+        let idTokenExistsPredicate = NSPredicate(format: "label LIKE 'Fetched ID Token:*'")
+        waitForElementToAppear(app.staticTexts.containing(idTokenExistsPredicate).element(boundBy: 0))
 
         // tap Create Order button
         app.buttons["Create Order"].tap()
@@ -105,9 +105,9 @@ class CardCheckout_UITests: XCTestCase {
         app = XCUIApplication()
         app.launch()
 
-        // wait for PP UAT
-        let uatExistsPredicate = NSPredicate(format: "label LIKE 'Fetched UAT:*'")
-        waitForElementToAppear(app.staticTexts.containing(uatExistsPredicate).element(boundBy: 0))
+        // wait for PP ID Token
+        let idTokenExistsPredicate = NSPredicate(format: "label LIKE 'Fetched ID Token:*'")
+        waitForElementToAppear(app.staticTexts.containing(idTokenExistsPredicate).element(boundBy: 0))
 
         // tap Create Order button
         app.buttons["Create Order"].tap()

--- a/UnitTests/Helpers/PayPalIDTokenTestHelper.swift
+++ b/UnitTests/Helpers/PayPalIDTokenTestHelper.swift
@@ -1,6 +1,6 @@
-class PayPalUATTestHelper {
+class PayPalIDTokenTestHelper {
     
-    static func encodeUAT(_ dict: [String : Any]) -> String {
+    static func encodeToken(_ dict: [String : Any]) -> String {
         let data = try! JSONSerialization.data(withJSONObject: dict, options: .prettyPrinted)
         return "123.\(data.base64EncodedString().replacingOccurrences(of: "=", with: "")).456"
     }

--- a/UnitTests/PYPLAPIClient_Tests.swift
+++ b/UnitTests/PYPLAPIClient_Tests.swift
@@ -28,7 +28,7 @@ class PYPLAPIClient_Tests: XCTestCase {
     
     override func setUp() {
         super.setUp()
-        idTokenString = PayPalUATTestHelper.encodeUAT(idTokenParams)
+        idTokenString = PayPalIDTokenTestHelper.encodeToken(idTokenParams)
         mockBTAPIClient = MockBTAPIClient(authorization: idTokenString)
         
         payPalAPIClient = PYPLAPIClient(idToken: idTokenString)!
@@ -38,11 +38,11 @@ class PYPLAPIClient_Tests: XCTestCase {
     
     // MARK: - initialization
 
-    func testInitWithAccessToken_returnsAPIClient() {
+    func testInitWithIDTokenToken_returnsAPIClient() {
         XCTAssertNotNil(PYPLAPIClient(idToken: idTokenString))
     }
     
-    func testInitWithInvalidAccessToken_returnsNil() {
+    func testInitWithInvalidIDToken_returnsNil() {
         XCTAssertNil(PYPLAPIClient(idToken: "invalid-token"))
     }
 

--- a/UnitTests/PYPLAPIClient_Tests.swift
+++ b/UnitTests/PYPLAPIClient_Tests.swift
@@ -2,7 +2,7 @@ import XCTest
 
 class PYPLAPIClient_Tests: XCTestCase {
   
-    let uatParams: [String : Any] = [
+    let idTokenParams: [String : Any] = [
         "iss": "https://api.sandbox.paypal.com",
         "sub": "PayPal:fake-pp-merchant",
         "acr": [
@@ -19,7 +19,7 @@ class PYPLAPIClient_Tests: XCTestCase {
         "jti": "fake-jti"
     ]
     
-    var uatString: String!
+    var idTokenString: String!
     var payPalAPIClient: PYPLAPIClient!
     var mockBTAPIClient: MockBTAPIClient!
     
@@ -28,10 +28,10 @@ class PYPLAPIClient_Tests: XCTestCase {
     
     override func setUp() {
         super.setUp()
-        uatString = PayPalUATTestHelper.encodeUAT(uatParams)
-        mockBTAPIClient = MockBTAPIClient(authorization: uatString)
+        idTokenString = PayPalUATTestHelper.encodeUAT(idTokenParams)
+        mockBTAPIClient = MockBTAPIClient(authorization: idTokenString)
         
-        payPalAPIClient = PYPLAPIClient(accessToken: uatString)!
+        payPalAPIClient = PYPLAPIClient(idToken: idTokenString)!
         payPalAPIClient.urlSession = mockURLSession
         payPalAPIClient.braintreeAPIClient = mockBTAPIClient
     }
@@ -39,11 +39,11 @@ class PYPLAPIClient_Tests: XCTestCase {
     // MARK: - initialization
 
     func testInitWithAccessToken_returnsAPIClient() {
-        XCTAssertNotNil(PYPLAPIClient(accessToken: uatString))
+        XCTAssertNotNil(PYPLAPIClient(idToken: idTokenString))
     }
     
     func testInitWithInvalidAccessToken_returnsNil() {
-        XCTAssertNil(PYPLAPIClient(accessToken: "invalid-token"))
+        XCTAssertNil(PYPLAPIClient(idToken: "invalid-token"))
     }
 
     // MARK: -  validatePaymentMethod
@@ -59,7 +59,7 @@ class PYPLAPIClient_Tests: XCTestCase {
             
             XCTAssertEqual(request.httpMethod, "POST")
             XCTAssertEqual(request.url?.absoluteString, "https://api.sandbox.paypal.com/v2/checkout/orders/order-id/validate-payment-method")
-            XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer \(self.uatString!)")
+            XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer \(self.idTokenString!)")
             XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/json")
             XCTAssertEqual(body, try! BTJSON(withJSONFile: "paypal-validate-request-with-3ds")?.asJSON())
             expectation.fulfill()
@@ -81,7 +81,7 @@ class PYPLAPIClient_Tests: XCTestCase {
 
             XCTAssertEqual(request.httpMethod, "POST")
             XCTAssertEqual(request.url?.absoluteString, "https://api.sandbox.paypal.com/v2/checkout/orders/order-id/validate-payment-method")
-            XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer \(self.uatString!)")
+            XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer \(self.idTokenString!)")
             XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/json")
             XCTAssertEqual(body, try! BTJSON(withJSONFile: "paypal-validate-request-without-3ds")?.asJSON())
             expectation.fulfill()

--- a/UnitTests/PYPLClient_Tests.swift
+++ b/UnitTests/PYPLClient_Tests.swift
@@ -2,14 +2,14 @@ import XCTest
 
 class PYPLClient_Tests: XCTestCase {
 
-    let uatParams: [String : Any] = [
+    let idTokenParams: [String : Any] = [
       "iss": "https://api.sandbox.paypal.com",
       "external_id": [
         "Braintree:merchant-id"
       ]
     ]
     
-    var uatString: String!
+    var idTokenString: String!
     
     var payPalClient: PYPLClient!
     let paymentRequest = PKPaymentRequest()
@@ -22,10 +22,10 @@ class PYPLClient_Tests: XCTestCase {
     let mockViewControllerPresentingDelegate = MockViewControllerPresentingDelegate()
 
     override func setUp() {
-        uatString = PayPalUATTestHelper.encodeUAT(uatParams)
+        idTokenString = PayPalUATTestHelper.encodeUAT(idTokenParams)
         
-        payPalClient = PYPLClient(accessToken: uatString)
-        mockBTAPIClient = MockBTAPIClient(authorization: uatString)
+        payPalClient = PYPLClient(idToken: idTokenString)
+        mockBTAPIClient = MockBTAPIClient(authorization: idTokenString)
         
         let defaultPaymentRequest = PKPaymentRequest()
         defaultPaymentRequest.countryCode = "US"
@@ -62,18 +62,18 @@ class PYPLClient_Tests: XCTestCase {
     // MARK: - initWithAccessToken
 
     func testClientInitialization_withUAT_initializesAllProperties() {
-        let payPalClient = PYPLClient(accessToken: uatString)
+        let payPalClient = PYPLClient(idToken: idTokenString)
         XCTAssertNotNil(payPalClient)
         XCTAssertNotNil(payPalClient?.payPalAPIClient)
         XCTAssertNotNil(payPalClient?.braintreeAPIClient)
         XCTAssertNotNil(payPalClient?.paymentFlowDriver)
         XCTAssertNotNil(payPalClient?.cardClient)
         XCTAssertNotNil(payPalClient?.applePayClient)
-        XCTAssertNotNil(payPalClient?.payPalUAT)
+        XCTAssertNotNil(payPalClient?.payPalIDToken)
     }
 
     func testClientInitialization_withInvalidUAT_returnsNil() {
-        let payPalClient = PYPLClient(accessToken: "header.invalid_paypal_uat_body.signature")
+        let payPalClient = PYPLClient(idToken: "header.invalid_paypal_id_token_body.signature")
         XCTAssertNil(payPalClient)
     }
     
@@ -584,14 +584,14 @@ class PYPLClient_Tests: XCTestCase {
     func testCheckoutWithPayPal_paymentFlowRequest_containsStagingCheckoutURL() {
         let expectation = self.expectation(description: "calls completion")
 
-        let uatParams: [String : Any] = [
+        let idTokenParams: [String : Any] = [
           "iss": "https://api.msmaster.qa.paypal.com",
           "external_id": [
             "Braintree:merchant-id"
           ]
         ]
 
-        payPalClient = PYPLClient(accessToken: PayPalUATTestHelper.encodeUAT(uatParams))
+        payPalClient = PYPLClient(idToken: PayPalUATTestHelper.encodeUAT(idTokenParams))
         mockPaymentFlowDriver = MockPaymentFlowDriver(apiClient: mockBTAPIClient)
         payPalClient?.paymentFlowDriver = mockPaymentFlowDriver
 
@@ -609,14 +609,14 @@ class PYPLClient_Tests: XCTestCase {
     func testCheckoutWithPayPal_paymentFlowRequest_containsProductionCheckoutURL() {
         let expectation = self.expectation(description: "calls completion")
 
-        let uatParams: [String : Any] = [
+        let idTokenParams: [String : Any] = [
             "iss": "https://api.paypal.com",
             "external_id": [
                 "Braintree:merchant-id"
             ]
         ]
 
-        payPalClient = PYPLClient(accessToken: PayPalUATTestHelper.encodeUAT(uatParams))
+        payPalClient = PYPLClient(idToken: PayPalUATTestHelper.encodeUAT(idTokenParams))
         mockPaymentFlowDriver = MockPaymentFlowDriver(apiClient: mockBTAPIClient)
         payPalClient?.paymentFlowDriver = mockPaymentFlowDriver
 

--- a/UnitTests/PYPLClient_Tests.swift
+++ b/UnitTests/PYPLClient_Tests.swift
@@ -22,7 +22,7 @@ class PYPLClient_Tests: XCTestCase {
     let mockViewControllerPresentingDelegate = MockViewControllerPresentingDelegate()
 
     override func setUp() {
-        idTokenString = PayPalUATTestHelper.encodeUAT(idTokenParams)
+        idTokenString = PayPalIDTokenTestHelper.encodeToken(idTokenParams)
         
         payPalClient = PYPLClient(idToken: idTokenString)
         mockBTAPIClient = MockBTAPIClient(authorization: idTokenString)
@@ -59,9 +59,9 @@ class PYPLClient_Tests: XCTestCase {
         mockBTAPIClient.postedAnalyticsEvents.removeAll()
     }
 
-    // MARK: - initWithAccessToken
+    // MARK: - initWithIDToken
 
-    func testClientInitialization_withUAT_initializesAllProperties() {
+    func testClientInitialization_withIDToken_initializesAllProperties() {
         let payPalClient = PYPLClient(idToken: idTokenString)
         XCTAssertNotNil(payPalClient)
         XCTAssertNotNil(payPalClient?.payPalAPIClient)
@@ -72,7 +72,7 @@ class PYPLClient_Tests: XCTestCase {
         XCTAssertNotNil(payPalClient?.payPalIDToken)
     }
 
-    func testClientInitialization_withInvalidUAT_returnsNil() {
+    func testClientInitialization_withInvalidIDToken_returnsNil() {
         let payPalClient = PYPLClient(idToken: "header.invalid_paypal_id_token_body.signature")
         XCTAssertNil(payPalClient)
     }
@@ -591,7 +591,7 @@ class PYPLClient_Tests: XCTestCase {
           ]
         ]
 
-        payPalClient = PYPLClient(idToken: PayPalUATTestHelper.encodeUAT(idTokenParams))
+        payPalClient = PYPLClient(idToken: PayPalIDTokenTestHelper.encodeToken(idTokenParams))
         mockPaymentFlowDriver = MockPaymentFlowDriver(apiClient: mockBTAPIClient)
         payPalClient?.paymentFlowDriver = mockPaymentFlowDriver
 
@@ -616,7 +616,7 @@ class PYPLClient_Tests: XCTestCase {
             ]
         ]
 
-        payPalClient = PYPLClient(idToken: PayPalUATTestHelper.encodeUAT(idTokenParams))
+        payPalClient = PYPLClient(idToken: PayPalIDTokenTestHelper.encodeToken(idTokenParams))
         mockPaymentFlowDriver = MockPaymentFlowDriver(apiClient: mockBTAPIClient)
         payPalClient?.paymentFlowDriver = mockPaymentFlowDriver
 


### PR DESCRIPTION
### Summary of changes

In braintree-ios, we renamed `PayPalUAT` to `PayPalIDToken` ([PR](https://github.braintreeps.com/team-sdk/braintree-ios/pull/559)). 

This PR reflects those updates.


### Checklist

~- [ ] Added a changelog entry~

### Authors
- @scannillo 